### PR TITLE
Sphinx2

### DIFF
--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -17,7 +17,7 @@ build:
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+  configuration: docs/source/conf.py
 
 # Optionally build your docs in additional formats such as PDF and ePub
 # formats:


### PR DESCRIPTION
This PR makes 2 small changes to the sphinx setup:
- It moves the readthedocs.yml file into the `docs/` folder'
- It points the conf.py file to source/conf.py, rather than docs/conf.py (this resolves an error thrown on the readthedocs end).